### PR TITLE
Fix `.get` example. Add `createReadStream` example

### DIFF
--- a/example/get.js
+++ b/example/get.js
@@ -2,4 +2,4 @@ var db = require('level')('/tmp/edit.db');
 var fdb = require('../')(db, { dir: '/tmp/edit.blob' });
 
 var hash = process.argv[2];
-fdb.get(hash).pipe(process.stdout);
+fdb.get(hash, console.log);

--- a/example/read.js
+++ b/example/read.js
@@ -1,0 +1,6 @@
+// get content (not metadata) for hash
+var db = require('level')('/tmp/edit.db');
+var fdb = require('../')(db, { dir: '/tmp/edit.blob' });
+
+var hash = process.argv[2];
+fdb.createReadStream(hash).pipe(process.stdout);


### PR DESCRIPTION
`examples/get.js` produces an error